### PR TITLE
update devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "sasslint": "sass-lint -c .sass-lint.yml -v -f table"
   },
   "devDependencies": {
-    "concurrently": "^5.1.0",
+    "concurrently": "^7.0.0",
     "live-server": "^1.2.1",
-    "node-sass": "^4.13.1",
+    "node-sass": "^7.0.1",
     "normalize.css": "^8.0.1",
     "sass-lint": "^1.13.1",
     "tjw-sasslint-rules": "^2.1.0"


### PR DESCRIPTION
The current package.json is not compatible and creates errors when user runs `npm install`

This change makes sure everything runs smoothly and new users do not have to manually install and use npm-check-update on their local machines.

Current update works as of March 10th, 2022